### PR TITLE
add redirections to canonical domain (#54)

### DIFF
--- a/src/EventSubscriber/RedirectDomainsSubscriber.php
+++ b/src/EventSubscriber/RedirectDomainsSubscriber.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+class RedirectDomainsSubscriber implements EventSubscriberInterface {
+	public function __construct () {
+	}
+
+	public static function getSubscribedEvents () {
+		return [
+				KernelEvents::REQUEST => [ [ 'onKernelRequest' ] ],
+		];
+	}
+
+	public function onKernelRequest ( GetResponseEvent $event ) {
+		$request = $event->getRequest();
+		$host    = $request->getHost();
+
+		switch ( $host ) {
+			case 'naturadapt.com':
+			case 'naturadapt.fr':
+			case 'www.naturadapt.fr':
+			case 'naturadapt.eu':
+			case 'www.naturadapt.eu':
+				if ( NULL !== $qs = $request->getQueryString() ) {
+					$qs = '?' . $qs;
+				}
+				$uri = $request->getBaseUrl() . $request->getPathInfo() . $qs;
+				$event->setResponse( new RedirectResponse( 'https://www.naturadapt.com' . $uri, 301 ) );
+				break;
+		}
+	}
+}

--- a/src/EventSubscriber/UserLocaleSubscriber.php
+++ b/src/EventSubscriber/UserLocaleSubscriber.php
@@ -22,6 +22,14 @@ class UserLocaleSubscriber implements EventSubscriberInterface {
 		$this->session       = $session;
 	}
 
+	public static function getSubscribedEvents () {
+		return [
+			// must be registered before (i.e. with a higher priority than) the default Locale listener
+			KernelEvents::REQUEST             => [ [ 'onKernelRequest', 20 ] ],
+			SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin',
+		];
+	}
+
 	public function onKernelRequest ( GetResponseEvent $event ) {
 		$request = $event->getRequest();
 
@@ -45,13 +53,5 @@ class UserLocaleSubscriber implements EventSubscriberInterface {
 		if ( NULL !== $user->getLocale() ) {
 			$this->session->set( '_locale', $user->getLocale() );
 		}
-	}
-
-	public static function getSubscribedEvents () {
-		return [
-			// must be registered before (i.e. with a higher priority than) the default Locale listener
-			KernelEvents::REQUEST             => [ [ 'onKernelRequest', 20 ] ],
-			SecurityEvents::INTERACTIVE_LOGIN => 'onInteractiveLogin',
-		];
 	}
 }


### PR DESCRIPTION
Close #54 

On peut créer une redirection depuis Symfony, mais ça introduit des URLs en dur dans le repo ?
Ici je redirige les hosts :
```
case 'naturadapt.com':
case 'naturadapt.fr':
case 'www.naturadapt.fr':
case 'naturadapt.eu':
case 'www.naturadapt.eu':
```
vers `https://www.naturadapt.com`