### PR TITLE
 lien utile dans menu footer

### DIFF
--- a/templates/layout/footer.html.twig
+++ b/templates/layout/footer.html.twig
@@ -26,7 +26,7 @@
 				<li>
 					<span>Liens utiles</span>
 					<ul>
-						<li><a href="{{ path('homepage') }}">À propos du projet</a></li>
+						<li><a href="{{ path('group_page_index', { groupSlug: 'communaute', pageSlug: 'newsletter' }) }}">Newsletter</a></li>
 						<li><a href="{{ path('groups_index') }}">Groupes</a></li>
 						<li><a href="/members">Annuaire</a></li>
 					</ul>


### PR DESCRIPTION
j'ai essayé de remplacer ds Liens utiles le lien 'à propos du projet par un d'une page newsletter
la page en prod est : https://naturadapt.com/groups/communaute/pages/newsletter

Pour créer l'url "path" j'ai copié/collé celle du même type sur le menu header : https://github.com/telabotanica/naturadapt/blob/97fec1e5ab9aee389f170b28c15cb8dfdb75441f/templates/layout/header.html.twig
Je ne sais pas si c'est bien comme ça 🤔