### PR TITLE
Fixed EnventDispacher::dispatch switched params

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -221,7 +221,7 @@ class UserController extends AbstractController {
 		$tokenStorage->setToken( $token );
 		$session->set( '_security_main', serialize( $token ) );
 		$event = new InteractiveLoginEvent( $request, $token );
-		$eventDispatcher->dispatch( 'security.interactive_login', $event );
+		$eventDispatcher->dispatch( $event, 'security.interactive_login' );
 
 		// Redirect to profile
 


### PR DESCRIPTION
`EnventDispacher::dispatch` params have been switched since Symfony 4.3
and the second one is commented but php does not break when passing
extra argument `$eventName` :
```
public function dispatch($event/*, string $eventName = null*/) 
{ 
    $eventName = 1 < \func_num_args() ? func_get_arg(1) : null;
...

```
See closed Symfony issue at [Symfony#32042](https://github.com/symfony/symfony/issues/32042)