### PR TITLE
Use AccessDeniedException instead of Http

### DIFF
--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -19,9 +19,9 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class GroupController extends AbstractController {
 	/**************************************************

--- a/src/Controller/GroupController.php
+++ b/src/Controller/GroupController.php
@@ -19,7 +19,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -225,7 +225,7 @@ class GroupController extends AbstractController {
 		}
 
 		if ( !$userGroupRelation->isCommunityAdmin( $this->getUser() ) ) {
-			throw new AccessDeniedHttpException( 'Your are not allowed to activate groups' );
+			throw new AccessDeniedException( 'Your are not allowed to activate groups' );
 		}
 
 		$group = $manager->getRepository( Usergroup::class )


### PR DESCRIPTION
The AccessDeniedHttpException bypasses the Symfony Security component and always results in a 403 response. You should throw AccessDeniedException (without Http) instead, so that the Security Component displays a login form.

see https://insight.symfony.com/projects/68562c9c-01f4-469a-aab5-9e06b288e91d/analyses/78?status=violations#912758800