### PR TITLE
Disable auto cache:clear for Production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,9 @@ jobs:
       - run: php bin/console doctrine:migrations:migrate --no-interaction
       - run: php bin/console doctrine:fixtures:load --no-interaction
 
+      # Cache warmup
+      - run: php bin/console cache:clear
+
       # run webpack
       - run: npm run build
 

--- a/clevercloud/post_build.sh
+++ b/clevercloud/post_build.sh
@@ -2,6 +2,9 @@
 ./bin/console doctrine:migrations:sync-metadata-storage --no-interaction
 ./bin/console doctrine:migrations:migrate --no-interaction
 
+# Cache warmup
+./bin/console cache:clear
+
 # Fixtures
 ./bin/console import:skills
 

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,6 @@
     },
     "scripts": {
         "auto-scripts": {
-            "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },
         "post-install-cmd": [


### PR DESCRIPTION
Fix deployment crash in case of database migrations:
composer install and auto cache:clear runs before migrations,
so auto cache:clear needs to be disabled and run after migrations.