### PR TITLE
Enable exif orientation for thumbnails

### DIFF
--- a/config/packages/liip_imagine.yaml
+++ b/config/packages/liip_imagine.yaml
@@ -15,6 +15,7 @@ liip_imagine:
             cache: ~
             quality: 75
             filters:
+                auto_rotate: ~
                 thumbnail:
                     mode: outbound
                     size: [52, 52]
@@ -24,6 +25,7 @@ liip_imagine:
             cache: ~
             quality: 75
             filters:
+                auto_rotate: ~
                 thumbnail:
                     mode: outbound
                     size: [150, 150]
@@ -33,6 +35,7 @@ liip_imagine:
             cache: ~
             quality: 75
             filters:
+                auto_rotate: ~
                 thumbnail:
                     mode: outbound
                     size: [300, 300]
@@ -42,6 +45,7 @@ liip_imagine:
             cache: ~
             quality: 75
             filters:
+                auto_rotate: ~
                 thumbnail:
                     mode: outbound
                     size: [1366, 380]
@@ -51,6 +55,7 @@ liip_imagine:
             cache: ~
             quality: 75
             filters:
+                auto_rotate: ~
                 thumbnail:
                     mode: outbound
                     size: [584, 330]
@@ -60,5 +65,6 @@ liip_imagine:
             cache: ~
             quality: 75
             filters:
+                auto_rotate: ~
                 downscale:
                     max: [480, 480]


### PR DESCRIPTION
Fix #248 