### PR TITLE
Add staging env to disallow search engine index

### DIFF
--- a/config/packages/staging/framework.yaml
+++ b/config/packages/staging/framework.yaml
@@ -1,0 +1,2 @@
+framework:
+  disallow_search_engine_index: true

--- a/config/packages/staging/import.yaml
+++ b/config/packages/staging/import.yaml
@@ -1,0 +1,2 @@
+imports:
+  - { resource: '../prod/' }


### PR DESCRIPTION
To enable, just switch `APP_ENV=prod` to `APP_ENV=staging` in staging 