### PR TITLE
modifs des liens des diverses navs

### DIFF
--- a/config/platform/default.config.yaml
+++ b/config/platform/default.config.yaml
@@ -150,7 +150,10 @@ menus:
             lien: '/groups/communaute/pages/ressources/'
         -
             nom: Actualités
-            lien: '/groups/communaute/articles/'
+            lien: '/groups/communaute/articles/'          
+        -
+            nom: Annuaire
+            lien: '/members'
     footbarFirstLiens:
         title: 'Menu'
         liens:
@@ -161,46 +164,43 @@ menus:
             nom: 'Connexion / Inscription'
             lien: '/login/'
         -
+            nom: Groupes
+            lien: '/groups/'
+        -
             nom: Annuaire
             lien: '/members/'
         -
             nom: Ressources
             lien: '/groups/communaute/pages/ressources/'
-        -
-            nom: Groupes
-            lien: '/groups/'
-        -
-            nom: Nouveau
-            lien: neuf
     footbarSecondLiens:
         title: 'En savoir plus'
         liens:
         -
-            nom: 'À propos du projet Natur’Adapt'
-            lien: '/about'
-        -
             nom: Newsletter
-            lien: '/newsletter'
+            lien: '/communaute/pages/newsletter'
+        -
+            nom: 'À propos du projet Natur’Adapt'
+            lien: 'groups/communaute/pages/a-propos-du-projet-natur-adapt
         -
             nom: 'À propos de la plateforme'
-            lien: '/platform'
+            lien: '/groups/communaute/pages/a-propos-de-la-plateforme'
         -
             nom: 'Charte de la plateforme'
-            lien: '/charte/'
+            lien: '/groups/communaute/pages/charte-de-la-plateforme'
         -
             nom: 'Mentions Légales'
-            lien: '/legal'
+            lien: '/groups/plateforme-web/pages/mentions-legales'
     footbarThirdLiens:
         title: 'Aide'
         liens:
         -
             nom: 'Tutoriels d’utilisation de la plateforme'
-            lien: '/groups/communaute/tutoriels'
+            lien: '/groups/communaute/tutoriels-d-utilisation-de-la-plateforme'
         -
             nom: 'Règles d’utilisation de la plateforme'
-            lien: '/rules'
+            lien: '/groups/plateforme-web/pages/regles'
         -
             nom: 'Signaler un problème'
-            lien: '/report'
+            lien: 'mailto:support@naturadapt.com'
 
 


### PR DESCRIPTION
Lié à #341 
Les urls des menus sur staging (et pré rempli dans l'interface admin)  ne sont pas les bons (c'est à dire ce ne sont pas ceux de la prod).  si ceux-ci sont gérés via le code il faudrait les modifier, si il vaut mieux le faire via cette interface d'admin alors lors de la mise en prod il faut absolument changer ceux ci dans la foulée. je propose une modif, de ce que j'ai trouvé, je ne sais pas si c'est le bon moyen de faire, s'il vaut mieux faire autrement, s'il y a d'autres fichiers à modifier. je n'ai pas testé en local (je l'ai pas ici), j'ai juste fait la modif via l'interface de Github

voir ticket lié #383 